### PR TITLE
master: fixed compare of ldap_result return value

### DIFF
--- a/src/TRLDAPConnection.m
+++ b/src/TRLDAPConnection.m
@@ -416,7 +416,7 @@ finish:
     }
 
     /* Wait for the result */
-    if (ldap_result(ldapConn, msgid, 1, &timeout, &res) == -1) {
+    if (ldap_result(ldapConn, msgid, 1, &timeout, &res) <= 0) {
         err = ldap_get_errno(ldapConn);
         if (err == LDAP_TIMEOUT)
             ldap_abandon_ext(ldapConn, msgid, NULL, NULL);


### PR DESCRIPTION
I'm in the process of testing this to address an issue I'm seeing in a production system.  It looks right to me, but I'd appreciate more eyes on it.
