### PR TITLE
Support for OpenVPN Challenge/Response protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+Makefile
+Mk/autoconf.mk
+Mk/compile.mk
+Mk/subdir.mk
+autom4te.cache/
+config.h
+config.h.in
+config.log
+config.status
+configure
+docs/Makefile
+docs/doxyfile
+src/Makefile
+tests/Makefile
+tools/Makefile
+AuthLDAP.xcodeproj/project.xcworkspace/xcuserdata/
+AuthLDAP.xcodeproj/xcuserdata/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The OpenVPN Auth-LDAP Plugin implements username/password authentication via LDA
   * LDAP group-based access restrictions.
   * Integration with the OpenBSD packet filter, supporting adding and removing VPN clients from PF tables based on group membership.
   * Tested against OpenLDAP, the plugin will authenticate against any LDAP server that supports LDAP simple binds -- including Active Directory.
+  * Supports OpenVPN Challenge/Response protocol, enabling it to be used in combination with one time password systems like Google Authenticator
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,37 @@ The OpenVPN Auth-LDAP Plugin implements username/password authentication via LDA
 To build, you will need to configure the sources appropriately. Example:
 
 ```
-./configure --prefix=/usr/local --with-openldap=/usr/local --with-openvpn=/usr/ports/security/openvpn/work/openvpn-2.0.2
+./configure --prefix=/usr/local --with-openldap=/usr/local --with-openvpn=/home/sean/work/openvpn-2.0.2
 ```
 
-The module will be build in src/openvpn-auth-ldap.so and installed as
+The module will be built in src/openvpn-auth-ldap.so and installed as
 `${prefix}/lib/openvpn-auth-ldap.so`.
+
+
+#### Building On Ubuntu 16.04 ####
+
+The following steps were tested on a clean Ubuntu 16.04 LTS Amazon EC2 m5.large instance in January 2018 (source AMI: ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20180109 - ami-41e0b93b).
+
+If you wish to repeat this process, follow these steps on your own machine:
+
+```
+git clone https://github.com/snowrider311/openvpn-auth-ldap
+cd openvpn-auth-ldap/
+./ubuntu_16.04_lts_build.sh
+```
+
+The `ubuntu_16.04_lts_build.sh` script will install all needed build dependencies, perform the build, and install `openvpn-auth-ldap.so` to `/usr/local/lib`.
+
+If you then wish to create a Debian package, you can then run this script:
+
+```
+./ubuntu_16.04_lts_package.sh
+```
+
+That script will install [FPM](https://github.com/jordansissel/fpm) and then use it to build a Debian package. If you then run `sudo dpkg -i openvpn-auth-ldap-snowrider311_2.0.3-1_amd64.deb`, then `openvpn-auth-ldap.so` will be installed to `/usr/lib/openvpn`, the same location as the standard, unforked `openvpn-auth-ldap` Debian package installs to. 
+
+Note: Superuser privileges are required to run these scripts.
+
 
 ## Usage
 

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -157,11 +157,20 @@ AC_DEFUN([OD_OBJC_RUNTIME],[
 			AC_LINK_IFELSE([
 					AC_LANG_PROGRAM([
 							#include <objc/objc.h>
+							#ifdef __GNU_LIBOBJC__
+							#include <objc/runtime.h>
+							#else
 							#include <objc/objc-api.h>
+							#endif
 						], [
+							#ifdef __GNU_LIBOBJC_
+							Class class = objc_lookUpClass("Object");
+							puts(class_getName(class));_
+							#else
 							id class = objc_lookup_class("Object");
 							id obj = @<:@class alloc@:>@;
 							puts(@<:@obj name@:>@);
+							#endif
 						])
 					], [
 						od_cv_objc_runtime_gnu="yes"

--- a/auth-ldap.conf
+++ b/auth-ldap.conf
@@ -46,6 +46,8 @@
 	# Add non-group members to a PF table (disabled)
 	#PFTable	ips_vpn_users
 
+	# Uncomment and set to true to support OpenVPN Challenge/Response
+	#PasswordIsCR	false
 	<Group>
 		# Match full user DN if true, uid only if false
 		RFC2307bis	true

--- a/auth-ldap.conf
+++ b/auth-ldap.conf
@@ -49,8 +49,13 @@
 	# Uncomment and set to true to support OpenVPN Challenge/Response
 	#PasswordIsCR	false
 	<Group>
-		# Match full user DN if true, uid only if false
-		RFC2307bis	true
+		# Default is true. Match full user DN if true, uid only if false.
+		# RFC2307bis   true
+
+		# Default is true. Uncomment and set to false if you want to use a Search operation to determine group
+		# membership instead of Compare. Lower performance, so Compare should generally be used, but Search is
+		# required in certain LDAP environments.
+		# UseCompareOperation   true
 
 		BaseDN		"ou=Groups,dc=example,dc=com"
 		SearchFilter	"(|(cn=developers)(cn=artists))"

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -34,7 +34,9 @@ AUTH_OBJS=	TRArray.o \
 		TRVPNSession.o \
 		hash.o \
 		strlcpy.o \
-		xmalloc.o
+		xmalloc.o \
+		base64.o \
+		openvpn-cr.o
 		
 GEN_SRCS=	TRConfigParser.m \
 		TRConfigParser.h \

--- a/src/TRAuthLDAPConfig.h
+++ b/src/TRAuthLDAPConfig.h
@@ -60,6 +60,7 @@
     TRString *_pfTable;
     TRArray *_ldapGroups;
     BOOL _pfEnabled;
+	BOOL _passwordISCR;
 
     /* Parser State */
     TRString *_configFileName;
@@ -125,5 +126,8 @@
 - (void) setPFEnabled: (BOOL) newPFSetting;
 
 - (TRArray *) ldapGroups;
+
+- (BOOL) passWordIsCR;
+- (void) setPassWordIsCR: (BOOL)newCRSetting;
 
 @end

--- a/src/TRAuthLDAPConfig.m
+++ b/src/TRAuthLDAPConfig.m
@@ -78,6 +78,9 @@ typedef enum {
     LF_GROUP_MEMBER_ATTRIBUTE,  /* Group Membership Attribute */
     LF_GROUP_MEMBER_RFC2307BIS,	/* Look for full DN for user in attribute */
 
+	/* OpenVPN Challenge/Response */
+    LF_AUTH_PASSOWRD_CR,      /* Password is in challenge/repsonse format */
+
     /* Misc Shared */
     LF_UNKNOWN_OPCODE,          /* Unknown Opcode */
 } ConfigOpcode;
@@ -156,6 +159,13 @@ static OpcodeTable GroupSectionVariables[] = {
     { NULL, 0 }
 };
 
+/* OpenVPN Challenge/Response */
+static OpcodeTable OpenVPNCRVariables[] = {
+    /* name                 opcode                      multi   required */
+    { "PasswordIsCR",    LF_AUTH_PASSOWRD_CR,  NO,     NO },
+    { NULL, 0 }
+};
+
 /* Section Types */
 static OpcodeTable *Sections[] = {
     SectionTypes,
@@ -173,7 +183,8 @@ static OpcodeTable *AuthSection[] = {
     AuthSectionVariables,
     GenericLDAPVariables,
     GenericPFVariables,
-    NULL
+    OpenVPNCRVariables,
+	NULL
 };
 
 /* Group Section Definition */
@@ -181,6 +192,7 @@ static OpcodeTable *GroupSection[] = {
     GroupSectionVariables,
     GenericLDAPVariables,
     GenericPFVariables,
+
     NULL
 };
 
@@ -684,6 +696,7 @@ error:
 
             switch(opcodeEntry->opcode) {
                 BOOL requireGroup;
+				BOOL passWordCR;
 
                 case LF_AUTH_REQUIRE_GROUP:
                     if (![value boolValue: &requireGroup]) {
@@ -704,6 +717,14 @@ error:
                 case LF_AUTH_PFTABLE:
                     [self setPFTable: [value string]];
                     [self setPFEnabled: YES];
+                    break;
+
+                case LF_AUTH_PASSOWRD_CR:
+                   if (![value boolValue: &passWordCR]) {
+                        [self errorBoolValue: value];
+                        return;
+                    }
+                    [self setPassWordIsCR: passWordCR];
                     break;
 
                 /* Unknown Setting */
@@ -979,4 +1000,11 @@ error:
     return _ldapGroups;
 }
 
+- (BOOL) passWordIsCR {
+    return (_passwordISCR);
+}
+
+- (void) setPassWordIsCR: (BOOL) newCRSetting {
+    _passwordISCR = newCRSetting;
+}
 @end

--- a/src/TRAuthLDAPConfig.m
+++ b/src/TRAuthLDAPConfig.m
@@ -77,6 +77,7 @@ typedef enum {
     /* Group Section Variables */
     LF_GROUP_MEMBER_ATTRIBUTE,  /* Group Membership Attribute */
     LF_GROUP_MEMBER_RFC2307BIS,	/* Look for full DN for user in attribute */
+    LF_GROUP_MEMBER_USECOMPAREOPERATION, /* Use LDAP Compare operation instead of Search (Search is faster but doesn't work in all LDAP environments) */
 
 	/* OpenVPN Challenge/Response */
     LF_AUTH_PASSWORD_CR,      /* Password is in challenge/repsonse format */
@@ -155,7 +156,8 @@ static OpcodeTable AuthSectionVariables[] = {
 static OpcodeTable GroupSectionVariables[] = {
     /* name                 opcode                      multi   required */
     { "MemberAttribute",    LF_GROUP_MEMBER_ATTRIBUTE,  NO,     NO },
-    { "RFC2307bis",		LF_GROUP_MEMBER_RFC2307BIS, NO,	NO },
+    { "RFC2307bis",	        LF_GROUP_MEMBER_RFC2307BIS, NO,     NO },
+    { "UseCompareOperation", LF_GROUP_MEMBER_USECOMPAREOPERATION, NO, NO },
     { NULL, 0 }
 };
 
@@ -743,6 +745,7 @@ error:
             switch(opcodeEntry->opcode) {
                 TRLDAPGroupConfig *config;
                 BOOL memberRFC2307BIS;
+                BOOL useCompareOperation;
 
                 case LF_GROUP_MEMBER_ATTRIBUTE:
                     config = [self currentSectionContext];
@@ -756,6 +759,15 @@ error:
                         return;
                     }
                     [config setMemberRFC2307BIS: memberRFC2307BIS];
+                    break;
+
+                case LF_GROUP_MEMBER_USECOMPAREOPERATION:
+                    config = [self currentSectionContext];
+                    if (![value boolValue: &useCompareOperation]) {
+                        [self errorBoolValue: value];
+                        return;
+                    }
+                    [config setUseCompareOperation: useCompareOperation];
                     break;
 
                 case LF_LDAP_BASEDN:

--- a/src/TRAuthLDAPConfig.m
+++ b/src/TRAuthLDAPConfig.m
@@ -79,7 +79,7 @@ typedef enum {
     LF_GROUP_MEMBER_RFC2307BIS,	/* Look for full DN for user in attribute */
 
 	/* OpenVPN Challenge/Response */
-    LF_AUTH_PASSOWRD_CR,      /* Password is in challenge/repsonse format */
+    LF_AUTH_PASSWORD_CR,      /* Password is in challenge/repsonse format */
 
     /* Misc Shared */
     LF_UNKNOWN_OPCODE,          /* Unknown Opcode */
@@ -162,7 +162,7 @@ static OpcodeTable GroupSectionVariables[] = {
 /* OpenVPN Challenge/Response */
 static OpcodeTable OpenVPNCRVariables[] = {
     /* name                 opcode                      multi   required */
-    { "PasswordIsCR",    LF_AUTH_PASSOWRD_CR,  NO,     NO },
+    { "PasswordIsCR",    LF_AUTH_PASSWORD_CR,  NO,     NO },
     { NULL, 0 }
 };
 
@@ -719,7 +719,7 @@ error:
                     [self setPFEnabled: YES];
                     break;
 
-                case LF_AUTH_PASSOWRD_CR:
+                case LF_AUTH_PASSWORD_CR:
                    if (![value boolValue: &passWordCR]) {
                         [self errorBoolValue: value];
                         return;

--- a/src/TRLDAPGroupConfig.h
+++ b/src/TRLDAPGroupConfig.h
@@ -41,6 +41,7 @@
     TRString *_searchFilter;
     TRString *_memberAttribute;
     BOOL     _memberRFC2307BIS;
+    BOOL     _useCompareOperation;
     TRString *_pfTable;
 }
 
@@ -55,6 +56,9 @@
 
 - (BOOL) memberRFC2307BIS;
 - (void) setMemberRFC2307BIS: (BOOL) memberRFC2307BIS;
+
+- (BOOL) useCompareOperation;
+- (void) setUseCompareOperation: (BOOL) useCompareOperation;
 
 - (TRString *) pfTable;
 - (void) setPFTable: (TRString *) tableName;

--- a/src/TRLDAPGroupConfig.m
+++ b/src/TRLDAPGroupConfig.m
@@ -59,6 +59,7 @@
         return self;
 
     _memberRFC2307BIS = YES;
+    _useCompareOperation = YES;
     return self;
 }
 
@@ -98,6 +99,14 @@
 
 - (void) setMemberRFC2307BIS: (BOOL) memberRFC2307BIS {
     _memberRFC2307BIS = memberRFC2307BIS;
+}
+
+- (BOOL) useCompareOperation {
+    return (_useCompareOperation);
+}
+
+- (void) setUseCompareOperation: (BOOL) useCompareOperation {
+    _useCompareOperation = useCompareOperation;
 }
 
 - (void) setPFTable: (TRString *) tableName {

--- a/src/TRObject.h
+++ b/src/TRObject.h
@@ -39,6 +39,7 @@
 
 #import <stdint.h>
 #import <stdbool.h>
+#include <stdarg.h>
 
 #import "PXObjCRuntime.h"
 

--- a/src/base64.c
+++ b/src/base64.c
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2003 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * Copyright (c) 1999-2003 Apple Computer, Inc.  All Rights Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+/* ====================================================================
+ * Copyright (c) 1995-1999 The Apache Group.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. All advertising materials mentioning features or use of this
+ *    software must display the following acknowledgment:
+ *    "This product includes software developed by the Apache Group
+ *    for use in the Apache HTTP server project (http://www.apache.org/)."
+ *
+ * 4. The names "Apache Server" and "Apache Group" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For written permission, please contact
+ *    apache@apache.org.
+ *
+ * 5. Products derived from this software may not be called "Apache"
+ *    nor may "Apache" appear in their names without prior written
+ *    permission of the Apache Group.
+ *
+ * 6. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by the Apache Group
+ *    for use in the Apache HTTP server project (http://www.apache.org/)."
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE APACHE GROUP ``AS IS'' AND ANY
+ * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE APACHE GROUP OR
+ * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Group and was originally based
+ * on public domain software written at the National Center for
+ * Supercomputing Applications, University of Illinois, Urbana-Champaign.
+ * For more information on the Apache Group and the Apache HTTP server
+ * project, please see <http://www.apache.org/>.
+ *
+ */
+
+/* Base64 encoder/decoder. Originally Apache file ap_base64.c
+ */
+
+#include <string.h>
+
+#include "base64.h"
+
+/* aaaack but it's fast and const should make it shared text page. */
+static const unsigned char pr2six[256] =
+{
+    /* ASCII table */
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 64, 64, 63,
+    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 64, 64, 64, 64, 64,
+    64,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64, 64,
+    64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64
+};
+
+int Base64decode_len(const char *bufcoded)
+{
+    int nbytesdecoded;
+    register const unsigned char *bufin;
+    register int nprbytes;
+
+    bufin = (const unsigned char *) bufcoded;
+    while (pr2six[*(bufin++)] <= 63);
+
+    nprbytes = (bufin - (const unsigned char *) bufcoded) - 1;
+    nbytesdecoded = ((nprbytes + 3) / 4) * 3;
+
+    return nbytesdecoded + 1;
+}
+
+int Base64decode(char *bufplain, const char *bufcoded)
+{
+    int nbytesdecoded;
+    register const unsigned char *bufin;
+    register unsigned char *bufout;
+    register int nprbytes;
+
+    bufin = (const unsigned char *) bufcoded;
+    while (pr2six[*(bufin++)] <= 63);
+    nprbytes = (bufin - (const unsigned char *) bufcoded) - 1;
+    nbytesdecoded = ((nprbytes + 3) / 4) * 3;
+
+    bufout = (unsigned char *) bufplain;
+    bufin = (const unsigned char *) bufcoded;
+
+    while (nprbytes > 4) {
+    *(bufout++) =
+        (unsigned char) (pr2six[*bufin] << 2 | pr2six[bufin[1]] >> 4);
+    *(bufout++) =
+        (unsigned char) (pr2six[bufin[1]] << 4 | pr2six[bufin[2]] >> 2);
+    *(bufout++) =
+        (unsigned char) (pr2six[bufin[2]] << 6 | pr2six[bufin[3]]);
+    bufin += 4;
+    nprbytes -= 4;
+    }
+
+    /* Note: (nprbytes == 1) would be an error, so just ingore that case */
+    if (nprbytes > 1) {
+    *(bufout++) =
+        (unsigned char) (pr2six[*bufin] << 2 | pr2six[bufin[1]] >> 4);
+    }
+    if (nprbytes > 2) {
+    *(bufout++) =
+        (unsigned char) (pr2six[bufin[1]] << 4 | pr2six[bufin[2]] >> 2);
+    }
+    if (nprbytes > 3) {
+    *(bufout++) =
+        (unsigned char) (pr2six[bufin[2]] << 6 | pr2six[bufin[3]]);
+    }
+
+    *(bufout++) = '\0';
+    nbytesdecoded -= (4 - nprbytes) & 3;
+    return nbytesdecoded;
+}
+
+static const char basis_64[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+int Base64encode_len(int len)
+{
+    return ((len + 2) / 3 * 4) + 1;
+}
+
+int Base64encode(char *encoded, const char *string, int len)
+{
+    int i;
+    char *p;
+
+    p = encoded;
+    for (i = 0; i < len - 2; i += 3) {
+    *p++ = basis_64[(string[i] >> 2) & 0x3F];
+    *p++ = basis_64[((string[i] & 0x3) << 4) |
+                    ((int) (string[i + 1] & 0xF0) >> 4)];
+    *p++ = basis_64[((string[i + 1] & 0xF) << 2) |
+                    ((int) (string[i + 2] & 0xC0) >> 6)];
+    *p++ = basis_64[string[i + 2] & 0x3F];
+    }
+    if (i < len) {
+    *p++ = basis_64[(string[i] >> 2) & 0x3F];
+    if (i == (len - 1)) {
+        *p++ = basis_64[((string[i] & 0x3) << 4)];
+        *p++ = '=';
+    }
+    else {
+        *p++ = basis_64[((string[i] & 0x3) << 4) |
+                        ((int) (string[i + 1] & 0xF0) >> 4)];
+        *p++ = basis_64[((string[i + 1] & 0xF) << 2)];
+    }
+    *p++ = '=';
+    }
+
+    *p++ = '\0';
+    return p - encoded;
+}

--- a/src/base64.h
+++ b/src/base64.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2003 Apple Computer, Inc. All rights reserved.
+ *
+ * @APPLE_LICENSE_HEADER_START@
+ * 
+ * Copyright (c) 1999-2003 Apple Computer, Inc.  All Rights Reserved.
+ * 
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apple Public Source License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://www.opensource.apple.com/apsl/ and read it before using this
+ * file.
+ * 
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ * 
+ * @APPLE_LICENSE_HEADER_END@
+ */
+/* ====================================================================
+ * Copyright (c) 1995-1999 The Apache Group.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. All advertising materials mentioning features or use of this
+ *    software must display the following acknowledgment:
+ *    "This product includes software developed by the Apache Group
+ *    for use in the Apache HTTP server project (http://www.apache.org/)."
+ *
+ * 4. The names "Apache Server" and "Apache Group" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For written permission, please contact
+ *    apache@apache.org.
+ *
+ * 5. Products derived from this software may not be called "Apache"
+ *    nor may "Apache" appear in their names without prior written
+ *    permission of the Apache Group.
+ *
+ * 6. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by the Apache Group
+ *    for use in the Apache HTTP server project (http://www.apache.org/)."
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE APACHE GROUP ``AS IS'' AND ANY
+ * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE APACHE GROUP OR
+ * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Group and was originally based
+ * on public domain software written at the National Center for
+ * Supercomputing Applications, University of Illinois, Urbana-Champaign.
+ * For more information on the Apache Group and the Apache HTTP server
+ * project, please see <http://www.apache.org/>.
+ *
+ */
+
+
+
+#ifndef _BASE64_H_
+#define _BASE64_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int Base64encode_len(int len);
+int Base64encode(char * coded_dst, const char *plain_src,int len_plain_src);
+
+int Base64decode_len(const char * coded_src);
+int Base64decode(char * plain_dst, const char *coded_src);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //_BASE64_H_

--- a/src/openvpn-cr.c
+++ b/src/openvpn-cr.c
@@ -1,0 +1,77 @@
+#include "openvpn-cr.h"
+
+#include "base64.h"
+#include <string.h>
+
+static const char * static_cr_label = "SCRV1";
+static const char * dynamic_cr_label = "CRV1";
+
+int set_token_b64(const char * source, char * destination)
+{
+	if (Base64decode_len(source) >= MAXTOKENLENGTH)
+		return 0;
+	Base64decode(destination, source); 
+	return 1;
+}
+
+int set_token(const char * source, char * destination)
+{
+	if (strlen(source) >= MAXTOKENLENGTH)
+		return 0;
+	strncpy(destination, source, MAXTOKENLENGTH);
+	return 1;
+}
+
+
+int extract_openvpn_cr(const char *response, openvpn_response *result, char **error_message)
+{
+	const char *tokenIndexes[15];
+	tokenIndexes[0] = response;
+	int tokenCnt = 1;
+	const char *p;
+	for (p = response; *p; ++p) {
+		if (*p == ':')
+			tokenIndexes[tokenCnt++] = p + 1;
+	}
+
+	if (tokenCnt == 3 && strstr(response, static_cr_label) == response)
+	{
+		if (!set_token(static_cr_label, result->protocol)){
+			*error_message = "Unable to set static protocol information.";
+			return 0;
+		}
+
+		if (!set_token_b64(tokenIndexes[1], result->password)) {
+			*error_message = "Unable to extract password from static cr.";
+			return 0;
+		}
+
+		if (!set_token_b64(tokenIndexes[2], result->response)) {
+			*error_message = "Unable to extract response from static cr.";
+			return 0;
+		}
+	}
+	else if (tokenCnt == 5 && strstr(response, dynamic_cr_label) == response) {
+		if (!set_token(dynamic_cr_label, result->protocol)) {
+			*error_message = "Unable to set dynamic protocol information.";
+			return 0;
+		}
+
+		if (!set_token_b64(tokenIndexes[2], result->password)) {
+			*error_message = "Unable to extract password from dynamic cr.";
+			return 0;
+		}
+
+		if (!set_token_b64(tokenIndexes[4], result->response)) {
+			*error_message = "Unable to extract response from dynamic cr.";
+			return 0;
+		}
+	}
+	else {
+		*error_message = "Incorrectly formatted cr string.";
+		return 0;
+	}
+	return 1;
+}
+
+

--- a/src/openvpn-cr.h
+++ b/src/openvpn-cr.h
@@ -1,0 +1,19 @@
+#ifndef OPENVPN_CR_H
+#define OPENVPN_CR_H
+
+#define MAXTOKENLENGTH 1024
+
+typedef struct
+{
+	char protocol[6];
+	char password[MAXTOKENLENGTH];
+	char response[MAXTOKENLENGTH];
+} openvpn_response;
+
+/* Parse a string containing an openvpn response and store the result
+   into an openvpn_response struct.
+   If parsing succeeds result will be in result and 1 is returned.
+   If parsing fails, 0 is returned, error_message is set */
+int extract_openvpn_cr(const char *response, openvpn_response *result, char **error_message);
+
+#endif

--- a/tests/PXTestConsoleResultHandler.h
+++ b/tests/PXTestConsoleResultHandler.h
@@ -25,6 +25,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <time.h>
 #import "TRObject.h"
 #import "PXTestResultHandler.h"
 

--- a/ubuntu_16.04_lts_build.sh
+++ b/ubuntu_16.04_lts_build.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+# git clone https://github.com/snowrider311/openvpn-auth-ldap
+# cd openvpn-auth-ldap/
+# source ubuntu_16.04_lts_build.sh
+# source ubuntu_16.04_lts_package.sh
+
+sudo apt-get update
+sudo apt-get -y install openvpn autoconf re2c libtool libldap2-dev libssl-dev gobjc make
+./regen.sh
+./configure --with-openvpn=/usr/include/openvpn CFLAGS="-fPIC" OBJCFLAGS="-std=gnu11"
+make
+sudo make install

--- a/ubuntu_16.04_lts_package.sh
+++ b/ubuntu_16.04_lts_package.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+sudo apt-get install -y ruby ruby-dev rubygems build-essential
+sudo gem install --no-ri --no-rdoc fpm
+
+mkdir -p /tmp/openvpn-auth-ldap-build/usr/lib/openvpn
+sudo mv /usr/local/lib/openvpn-auth-ldap.so /tmp/openvpn-auth-ldap-build/usr/lib/openvpn
+fpm -s dir -C /tmp/openvpn-auth-ldap-build -t deb --name openvpn-auth-ldap-snowrider311 \
+  --version 2.0.3 --iteration 1 --depends openvpn --depends gnustep-base-runtime \
+  --depends libc6 --depends libgnustep-base1.24 --depends libldap-2.4-2 --depends libobjc4
+
+# To install:
+# sudo dpkg -i openvpn-auth-ldap-snowrider311_2.0.3-1_amd64.deb


### PR DESCRIPTION
As discussed in ticket #62, this patch adds support for the OpenVPN Challenge/Response protocol.

The implementation consists of adding an additional field to the config, ``PasswordIsCR`` (in the Auth section of the file):
````
   # Uncomment and set to true to support OpenVPN Challenge/Response
   #PasswordIsCR	false
````
If this flag is present and set to ``true`` the plugin will expect the password to be in the special Challenge/Response format and will parse and extract the password from there.

The typical usage scenario would be to use the **openvpn-auth-ldap** and **openvpn-otp** plug-ins together and be able to offer LDAP authentication enriched with an extra layer of security of one time passwords.

Guy Wyers