### PR TITLE
Delete empty CFLAGS from tools/Makefile.in in order to use the ones provided by autoconf

### DIFF
--- a/tools/Makefile.in
+++ b/tools/Makefile.in
@@ -11,7 +11,6 @@ include ${top_builddir}/Mk/subdir.mk
 LEMON_OBJS=	lemon.o
 
 MAKEHEADERS_OBJS=	makeheaders.o
-CFLAGS=
 
 all:: lemon makeheaders
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to OpenVPN
Auth-LDAP.
We thought you might be interested in it too.

    Subject: Delete empty CFLAGS from tools/Makefile.in in order to use the ones provided by autoconf
    Author: Aniol Marti <amarti@caliu.cat>
    Last-Update: 2019-07-12
    Index: openvpn-auth-ldap/tools/Makefile.in
    ===================================================================

The patch is tracked in our Git repository at
https://salsa.debian.org/debian/openvpn-auth-ldap/raw/master/debian/patches/tools-cflags.patch

Thanks for considering,
  Aniol Marti
