### PR TITLE
Load LDFLAGS passed when running configure

### DIFF
--- a/platform.m4
+++ b/platform.m4
@@ -95,9 +95,9 @@ AC_DEFUN(OD_CONFIG_PLUGIN, [
 	    # A sensible default
 	    PLUGIN_CFLAGS="-fPIC"
 	    PLUGIN_LD="${CC} -shared"
-	    PLUGIN_LD_FLAGS=""
+	    PLUGIN_LD_FLAGS="${LDFLAGS}"
 	    PLUGIN_SUFFIX=".so"
-	    LDFLAGS="-export-dynamic"
+	    LDFLAGS="-export-dynamic ${LDFLAGS}"
 	    ;;
     esac
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to OpenVPN
Auth-LDAP.
We thought you might be interested in it too.

    Subject: Load LDFLAGS passed when running configure
    Author: Aniol Marti <amarti@caliu.cat>
    Last-Update: 2019-07-12
    Index: openvpn-auth-ldap/platform.m4
    ===================================================================

The patch is tracked in our Git repository at
https://salsa.debian.org/debian/openvpn-auth-ldap/raw/master/debian/patches/load-ldflags.patch

Thanks for considering,
  Aniol Marti
