### PR TITLE
Move address checks further down to avoid certain failures

### DIFF
--- a/src/auth-ldap.m
+++ b/src/auth-ldap.m
@@ -523,7 +523,10 @@ static int handle_client_connect_disconnect(ldap_ctx *ctx, TRLDAPConnection *lda
     }
 
     if (tableName)
-        if (!pf_client_connect_disconnect(ctx, tableName, remoteAddress, connecting))
+        if (!remoteAddress) {
+            [TRLog debug: "No remote address supplied to OpenVPN LDAP Plugin (OPENVPN_PLUGIN_CLIENT_CONNECT)."];
+            return OPENVPN_PLUGIN_FUNC_ERROR;
+        } else if (!pf_client_connect_disconnect(ctx, tableName, remoteAddress, connecting))
         return OPENVPN_PLUGIN_FUNC_ERROR;
 #endif /* HAVE_PF */
 
@@ -582,18 +585,10 @@ openvpn_plugin_func_v1(openvpn_plugin_handle_t handle, const int type, const cha
             break;
         /* New connection established */
         case OPENVPN_PLUGIN_CLIENT_CONNECT:
-            if (!remoteAddress) {
-                [TRLog debug: "No remote address supplied to OpenVPN LDAP Plugin (OPENVPN_PLUGIN_CLIENT_CONNECT)."];
-            } else {
-                ret = handle_client_connect_disconnect(ctx, ldap, ldapUser, remoteAddress, YES);
-            }
+            ret = handle_client_connect_disconnect(ctx, ldap, ldapUser, remoteAddress, YES);
             break;
         case OPENVPN_PLUGIN_CLIENT_DISCONNECT:
-            if (!remoteAddress) {
-                [TRLog debug: "No remote address supplied to OpenVPN LDAP Plugin (OPENVPN_PLUGIN_CLIENT_DISCONNECT)."];
-            } else {
-                ret = handle_client_connect_disconnect(ctx, ldap, ldapUser, remoteAddress, NO);
-            }
+            ret = handle_client_connect_disconnect(ctx, ldap, ldapUser, remoteAddress, NO);
             break;
         default:
             [TRLog debug: "Unhandled plugin type in OpenVPN LDAP Plugin (type=%d)", type];


### PR DESCRIPTION
In Debian we are currently applying the following patch to OpenVPN
Auth-LDAP.
We thought you might be interested in it too.

    Description: move address checks further down to avoid certain failures
     this tries to avoid certain failures with the LDAP plugin where it
     doesn't get passed the remoteAddress in certain cases. since we do
     may not care about this address, we fail only when really necessary.
    Author: Antoine Beaupré <anarcat@debian.org>
    Origin: vendor
    Bug-Debian: http://bugs.debian.org/692936
    Last-Update: 2019-08-05
    Index: openvpn-auth-ldap/src/auth-ldap.m
    ===================================================================

The patch is tracked in our Git repository at
https://salsa.debian.org/debian/openvpn-auth-ldap/raw/master/debian/patches/auth-ldap-remoteAddress.patch

This pull request closes #4.

Thanks for considering,
  Aniol Marti
