### PR TITLE
Override username given by the user with the client cert CN

### DIFF
--- a/auth-ldap.conf
+++ b/auth-ldap.conf
@@ -43,6 +43,9 @@
 	# Require Group Membership
 	RequireGroup	false
 
+	# Use CN instead given username
+	UseCn false
+	
 	# Add non-group members to a PF table (disabled)
 	#PFTable	ips_vpn_users
 

--- a/src/TRAuthLDAPConfig.h
+++ b/src/TRAuthLDAPConfig.h
@@ -57,6 +57,7 @@
     TRString *_baseDN;
     TRString *_searchFilter;
     BOOL _requireGroup;
+    BOOL _useCn;
     TRString *_pfTable;
     TRArray *_ldapGroups;
     BOOL _pfEnabled;
@@ -118,6 +119,9 @@
 
 - (BOOL) requireGroup;
 - (void) setRequireGroup: (BOOL) requireGroup;
+
+- (BOOL) useCn;
+- (void) setUseCn: (BOOL) useCn;
 
 - (TRString *) pfTable;
 - (void) setPFTable: (TRString *) tableName;

--- a/src/TRAuthLDAPConfig.m
+++ b/src/TRAuthLDAPConfig.m
@@ -73,6 +73,7 @@ typedef enum {
 
     /* Authorization Section Variables */
     LF_AUTH_REQUIRE_GROUP,      /* Require Group Membership */
+    LF_AUTH_USE_CN,      /* Use CN instead of given user name */
 
     /* Group Section Variables */
     LF_GROUP_MEMBER_ATTRIBUTE,  /* Group Membership Attribute */
@@ -149,6 +150,7 @@ static OpcodeTable LDAPSectionVariables[] = {
 static OpcodeTable AuthSectionVariables[] = {
     /* name             opcode                  multi   required */
     { "RequireGroup",   LF_AUTH_REQUIRE_GROUP,  NO,     NO },
+    { "UseCn",   LF_AUTH_USE_CN,  NO,     NO },
     { NULL, 0}
 };
 
@@ -698,6 +700,7 @@ error:
 
             switch(opcodeEntry->opcode) {
                 BOOL requireGroup;
+                BOOL useCn;
 				BOOL passWordCR;
 
                 case LF_AUTH_REQUIRE_GROUP:
@@ -706,6 +709,14 @@ error:
                         return;
                     }
                     [self setRequireGroup: requireGroup];
+                    break;
+
+                case LF_AUTH_USE_CN:
+                    if (![value boolValue: &useCn]) {
+                        [self errorBoolValue: value];
+                        return;
+                    }
+                    [self setUseCn: useCn];
                     break;
 
                 case LF_LDAP_BASEDN:
@@ -916,6 +927,14 @@ error:
 - (void) setRequireGroup: (BOOL) requireGroup {
     _requireGroup = requireGroup;
 }
+
+- (BOOL) useCn {
+    return (_useCn);
+}
+- (void) setUseCn: (BOOL) useCn {
+    _useCn = useCn;
+}
+
 
 - (void) setSearchFilter: (TRString *) searchFilter {
     if (_searchFilter)

--- a/src/auth-ldap.m
+++ b/src/auth-ldap.m
@@ -543,9 +543,16 @@ openvpn_plugin_func_v1(openvpn_plugin_handle_t handle, const int type, const cha
 
     /* Per-request allocation pool. */
     pool = [[TRAutoreleasePool alloc] init];
-
-    username = get_env("username", envp);
-    TRString *userName=[[TRString alloc]initWithCString: username];
+	
+    if ([ctx->config useCn])
+	{
+		username = get_env("common_name", envp);
+	}
+	else
+	{
+		username = get_env("username", envp);
+	}
+	TRString *userName =[[TRString alloc]initWithCString: username];
     password = get_env("password", envp);
     remoteAddress = get_env("ifconfig_pool_remote_ip", envp);
 

--- a/tests/data/auth-ldap.conf
+++ b/tests/data/auth-ldap.conf
@@ -40,6 +40,9 @@
 	# Require Group Membership
 	RequireGroup	false
 
+	# Use CN instead given username
+	UseCn false
+
 	<Group>
 		BaseDN		"ou=Groups,dc=example,dc=com"
 		SearchFilter	"(|(cn=developers)(cn=artists))"


### PR DESCRIPTION
Override username given by the user with the client cert CN, when you use the option "UseCn true" in the config.