### PR TITLE
Check for gobjc availability on CentOS/RHEL/Rocky 8 (and later)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,9 +6,9 @@ AC_CONFIG_HEADERS(config.h)
 AC_CANONICAL_SYSTEM
 
 # Compiler
-AC_PROG_CC(clang gcc)
+AC_PROG_CC(clang gobjc gcc)
 AC_PROG_CC_C99
-AC_PROG_OBJC(clang gcc)
+AC_PROG_OBJC(clang gobjc gcc)
 TR_WERROR
 AC_CACHE_SAVE
 


### PR DESCRIPTION
Red Hat [decided to remove](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/considerations_in_adopting_rhel_8/compilers-and-development-tools_considerations-in-adopting-rhel-8) the support for the Objective C language for Red Hat Enterprise Linux 8 (and later) from the GCC packages. Unfortunately GCC is not really modular, so `/usr/bin/gcc` keeps telling "Objective-C compiler not installed on this system" until the alternative GCC `/usr/bin/gobjc` from the [gcc-objc RPM package from Fedora EPEL 8](https://bugzilla.redhat.com/show_bug.cgi?id=1983416) is being used.