### PR TITLE
Fix crash on close if LDAP initialization failed/when configuration file is not EOL-terminated

### DIFF
--- a/src/TRConfigLexer.re
+++ b/src/TRConfigLexer.re
@@ -72,7 +72,7 @@
 #define SC(cond)    LEXER_SC_ ## cond: LEXER_SC_ ## cond
 
 /* Check for end-of-input */
-#define CHECK_EOI()    if (_eoi) { return NULL; }
+#define CHECK_EOI()    if (_cursor >= _limit) { return NULL; }
 
 /* Skip a token */
 #define SKIP(cond)    CHECK_EOI(); goto LEXER_SC_ ## cond
@@ -115,10 +115,6 @@
 - (void) fill: (int) length {
     /* We just need to prevent re2c from walking off the end of our buffer */
     assert(_limit - _cursor >= 0);
-    if (_cursor == _limit) {
-        /* Save the cursor and signal EOI */
-        _eoi = _cursor;
-    }
 }
 
 - (TRConfigToken *) scan {

--- a/src/auth-ldap.m
+++ b/src/auth-ldap.m
@@ -247,6 +247,9 @@ OPENVPN_EXPORT void
 {
     ldap_ctx *ctx = handle;
 
+    if (!ctx)
+        return;
+
     /* Clean up the configuration file */
     [ctx->config release];
 


### PR DESCRIPTION
Add a simple check to ensure our LDAP context has been properly initialized before trying to release it on close