### PR TITLE
Fix CVE-2024-28820

### DIFF
--- a/src/openvpn-cr.c
+++ b/src/openvpn-cr.c
@@ -29,7 +29,7 @@ int extract_openvpn_cr(const char *response, openvpn_response *result, char **er
 	tokenIndexes[0] = response;
 	int tokenCnt = 1;
 	const char *p;
-	for (p = response; *p; ++p) {
+	for (p = response; *p && tokenCnt < 15; ++p) {
 		if (*p == ':')
 			tokenIndexes[tokenCnt++] = p + 1;
 	}


### PR DESCRIPTION
An attacker who can control the challenge/response password field could, with a valid LDAP username, pass a string with more than 14 colons into this field, causing a buffer overflow. This happens before the number of tokens is checked for validity below.

This commit ensures that the loop bails before attempting to write past the end of tokenIndexes; as of the currently-published protocol, any response with more than 15 fields is certainly invalid (and will be rejected below).